### PR TITLE
Fixed argument of `invoker` used in` UnaryClientInterceptor`

### DIFF
--- a/cache/middleware.go
+++ b/cache/middleware.go
@@ -102,7 +102,7 @@ func (m *Middleware) UnaryClientInterceptor(
 			opts...,
 		)
 	default:
-		return invoker(ctx, method, req, invoker, cc, opts...)
+		return invoker(ctx, method, req, reply, cc, opts...)
 	}
 }
 

--- a/cache/middleware_emulator_test.go
+++ b/cache/middleware_emulator_test.go
@@ -84,9 +84,13 @@ type TestData struct {
 func TestEmulator_SetGet(t *testing.T) {
 	client := initClient(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
 	key := datastore.IncompleteKey("test", nil)
+	defer func() {
+		if err := client.Delete(ctx, key); err != nil {
+			t.Error(err)
+		}
+		cancel()
+	}()
 
 	data := &TestData{Name: "foo"}
 

--- a/cache/middleware_emulator_test.go
+++ b/cache/middleware_emulator_test.go
@@ -96,6 +96,17 @@ func TestEmulator_SetGet(t *testing.T) {
 		t.Fatalf("failed to put new data: %+v", err)
 	}
 
+	var list []*TestData
+	q := datastore.NewQuery("test")
+	q = q.Filter("Name =", "foo")
+	if _, err := client.GetAll(ctx, q, &list); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(list) != 1 {
+		t.Errorf("retrieved data differed: %d (expected: %d)", len(list), 1)
+	}
+
 	var ret TestData
 
 	if err := client.Get(ctx, key, &ret); err != nil {
@@ -103,7 +114,7 @@ func TestEmulator_SetGet(t *testing.T) {
 	}
 
 	if ret.Name != data.Name {
-		t.Errorf("retrieved data differed: %s(expected: %s)", ret.Name, data.Name)
+		t.Errorf("retrieved data differed: %s (expected: %s)", ret.Name, data.Name)
 	}
 
 	ret.Name = ""
@@ -113,7 +124,7 @@ func TestEmulator_SetGet(t *testing.T) {
 	}
 
 	if ret.Name != data.Name {
-		t.Errorf("retrieved data FROM CACHE differed: %s(expected: %s)", ret.Name, data.Name)
+		t.Errorf("retrieved data FROM CACHE differed: %s (expected: %s)", ret.Name, data.Name)
 	}
 }
 


### PR DESCRIPTION
Issue #6 
`invoker(ctx, method, req, invoker, cc, opts...)`
↓
`invoker(ctx, method, req, reply, cc, opts...)`
